### PR TITLE
feat(nav): añade menú hamburguesa para formato móvil y corrige estado activo

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,10 +13,14 @@
       <a href="#"><img class="logo" src="assets/HC Store 3.png" alt="Logo HC Store"></a>
     </div>
 
-    <nav class="nav-menu">
-      <a class="is-active" href="#">Inicio</a>
-      <a href="#productos">Productos</a>
-      <a href="#contacto">Contacto</a>
+    <button class="nav-toggle" aria-controls="primary-menu" aria-expanded="false" aria-label="Abrir menú">
+      <span></span><span></span><span></span>
+    </button>
+
+    <nav id="primary-menu" class="nav-menu" role="menu">
+      <a role="menuitem" href="#">Inicio</a>
+      <a role="menuitem" href="#productos">Productos</a>
+      <a role="menuitem" href="#contacto">Contacto</a>
     </nav>
   </header>
 

--- a/script.js
+++ b/script.js
@@ -18,3 +18,20 @@ document.querySelectorAll('.card').forEach(card => {
     });
   });
 });
+
+const toggle = document.querySelector('.nav-toggle');
+const menu = document.querySelector('.nav-menu');
+
+if (toggle && menu) {
+  toggle.addEventListener('click', () => {
+    const open = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!open));
+    menu.classList.toggle('is-open', !open);
+  });
+
+  // Cierra al elegir un link
+  menu.querySelectorAll('a').forEach(a => a.addEventListener('click', () => {
+    toggle.setAttribute('aria-expanded', 'false');
+    menu.classList.remove('is-open');
+  }));
+}

--- a/style.css
+++ b/style.css
@@ -301,12 +301,67 @@ html, body {
   margin: 2rem 0 0;
 }
 
-@media (max-width:700px) {
+/* ---- Menu hamburguesa ---- */
+.nav-toggle {
+  display:none;
+  background:transparent;
+  border:0;
+}
+
+.nav-toggle span {
+  display:block;
+  width:27px;
+  height:3px;
+  margin:5px 0;
+  background:#fff;
+  transition:transform .2s, opacity .2s;
+}
+
+@media (max-width:700px){
+  .nav-toggle {
+    display:block;
+  }
+
+  .nav-menu {
+    position:absolute;
+    right:1.5rem;
+    top:75%;
+    display:none;
+    flex-direction:column;
+    gap:0;
+    background:#232425;
+    border-radius:12px;
+    padding:.5rem;
+  }
+  .nav-menu a {
+    color:#fff;
+    padding:.75rem 1.25rem;
+    display:block;
+    font-size:1rem;
+  }
+
+  .nav-menu.is-open {
+    display:flex;
+  }
+
+  .nav-toggle[aria-expanded="true"] span:nth-child(1) {
+    transform:translateY(8px) rotate(45deg);
+  }
+
+  .nav-toggle[aria-expanded="true"] span:nth-child(2) {
+    opacity:0;
+  }
+
+  .nav-toggle[aria-expanded="true"] span:nth-child(3) {
+    transform:translateY(-8px) rotate(-45deg);
+  }
+
   .footer-grid {
     grid-template-columns: 1fr;
     justify-items: center;
     text-align: center;
   }
+
   .footer-grid .footer-contact:last-of-type {
     text-align: center
   }


### PR DESCRIPTION
A partir del feedback que recibí en el canal #reto-feedback: hice algunas pequeñas modificaciones:
- Se agrego el menú hamburguesa para pantallas móviles con una transición suave (☰ → ✕) y viceversa.
- Se elimino la clase active que dejaba “Inicio” siempre subrayado.
- Se ajustan estilos para mejorar el comportamiento responsive en pantallas móviles.
<img width="1902" height="511" alt="Nav" src="https://github.com/user-attachments/assets/30d16f26-f737-45e0-b0c6-854af60d56fa" />
<img width="369" height="820" alt="Movil" src="https://github.com/user-attachments/assets/759c7e46-33b3-46df-932c-ab5ba21eb371" />
<img width="368" height="819" alt="Movil2" src="https://github.com/user-attachments/assets/a1ffbd10-079b-497e-ad28-8813d748c701" />

